### PR TITLE
Add static guess-the-number game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adivina el número</title>
+<style>
+  /* Mobile-first, one-column layout */
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 1rem; line-height: 1.5; }
+  main { max-width: 400px; margin: 0 auto; display: flex; flex-direction: column; gap: 1rem; }
+  button, input { font-size: 1rem; padding: 0.75rem; min-height: 44px; }
+  button:disabled { opacity: 0.5; }
+  button:focus, input:focus { outline: 2px solid #005fcc; outline-offset: 2px; }
+  .feedback { min-height: 1.5em; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Adivina el número</h1>
+  <button id="generateBtn" type="button">Generar número</button>
+  <form id="guessForm" autocomplete="off">
+    <label for="guessInput">Introduce tu número…</label>
+    <input id="guessInput" type="text" inputmode="numeric" pattern="[0-9.]*" placeholder="Introduce tu número…">
+    <button id="sendBtn" type="submit" disabled aria-disabled="true">Enviar</button>
+  </form>
+  <output id="feedback" aria-live="polite" class="feedback"></output>
+  <p id="attempts">Intentos: 0</p>
+  <button id="resetBtn" type="button">Reiniciar</button>
+</main>
+<script>
+// Lógica del juego de adivinar el número
+(function() {
+  const max = 3000000000;
+  let secret = null;
+  let attempts = 0;
+  const generateBtn = document.getElementById('generateBtn');
+  const guessInput = document.getElementById('guessInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const resetBtn = document.getElementById('resetBtn');
+  const feedback = document.getElementById('feedback');
+  const attemptsText = document.getElementById('attempts');
+  const form = document.getElementById('guessForm');
+
+  // Habilita o deshabilita el botón Enviar según la entrada y si existe número secreto
+  function updateSendState() {
+    const value = guessInput.value.trim();
+    const validPattern = /^\d+(?:\.\d{3})*$/;
+    const isValid = secret !== null && validPattern.test(value) &&
+                    (n => n >= 1 && n <= max)(Number(value.replace(/\./g, '')));
+    sendBtn.disabled = !isValid;
+    sendBtn.setAttribute('aria-disabled', String(sendBtn.disabled));
+    return isValid;
+  }
+
+  // Genera el número secreto
+  function generateSecret() {
+    if (window.crypto && crypto.getRandomValues) {
+      const arr = new Uint32Array(1);
+      crypto.getRandomValues(arr);
+      secret = arr[0] % max + 1;
+    } else {
+      secret = Math.floor(Math.random() * max) + 1;
+    }
+    generateBtn.disabled = true;
+    generateBtn.setAttribute('aria-disabled', 'true');
+    attempts = 0;
+    attemptsText.textContent = 'Intentos: 0';
+    feedback.textContent = '';
+    guessInput.value = '';
+    sendBtn.disabled = true;
+    sendBtn.setAttribute('aria-disabled', 'true');
+    guessInput.focus();
+  }
+
+  // Comprueba el intento del usuario
+  function handleGuess() {
+    if (!updateSendState()) return;
+    const guess = Number(guessInput.value.replace(/\./g, ''));
+    attempts++;
+    attemptsText.textContent = 'Intentos: ' + attempts;
+    if (guess === secret) {
+      feedback.textContent = 'Correcto';
+    } else if (guess < secret) {
+      feedback.textContent = 'Mayor';
+    } else {
+      feedback.textContent = 'Menor';
+    }
+    guessInput.value = '';
+    updateSendState();
+  }
+
+  // Reinicia el juego
+  function resetGame() {
+    secret = null;
+    attempts = 0;
+    attemptsText.textContent = 'Intentos: 0';
+    feedback.textContent = '';
+    guessInput.value = '';
+    generateBtn.disabled = false;
+    generateBtn.setAttribute('aria-disabled', 'false');
+    sendBtn.disabled = true;
+    sendBtn.setAttribute('aria-disabled', 'true');
+  }
+
+  // Valida la entrada en cada cambio
+  guessInput.addEventListener('input', () => {
+    const value = guessInput.value.trim();
+    const validPattern = /^\d+(?:\.\d{3})*$/;
+    if (value === '') {
+      feedback.textContent = '';
+    } else if (!validPattern.test(value)) {
+      feedback.textContent = 'Formato inválido';
+    } else {
+      const number = Number(value.replace(/\./g, ''));
+      if (number < 1 || number > max) {
+        feedback.textContent = 'Fuera de rango';
+      } else {
+        feedback.textContent = '';
+      }
+    }
+    updateSendState();
+  });
+
+  generateBtn.addEventListener('click', generateSecret);
+  resetBtn.addEventListener('click', resetGame);
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    if (!sendBtn.disabled) handleGuess();
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` hosting the Adivina el número game for GitHub Pages
- mobile-first layout with accessible form and feedback
- implements crypto-based random number, validation and attempt counter

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689931928e5c83239761519ee3a30f4d