### PR TITLE
Auto-prefill digits after each guess

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Juego de adivinar un número entre 1 y 3.000 millones.
 
 El juego muestra un historial de intentos y actualiza el rango "Menor" y
 "Mayor" según las pistas recibidas para ayudar a ajustar los siguientes
-intentos.
+intentos. Tras cada intento, el campo de entrada se rellena automáticamente
+con los dígitos conocidos gracias al rango.

--- a/index.html
+++ b/index.html
@@ -227,8 +227,7 @@
     const li = document.createElement('li');
     li.textContent = formatNumber(guess) + ' → ' + hint;
     historyList.appendChild(li);
-    guessInput.value = '';
-    updateSendState();
+    applyPreFill();
   }
 
   // Reinicia el juego
@@ -266,14 +265,18 @@
     updateSendState();
   });
 
-  preFillBtn.addEventListener('click', () => {
+  function applyPreFill() {
     if (commonPrefix !== '') {
       guessInput.value = formatNumber(Number(commonPrefix));
       feedback.textContent = '';
-      updateSendState();
-      guessInput.focus();
+    } else {
+      guessInput.value = '';
     }
-  });
+    updateSendState();
+    guessInput.focus();
+  }
+
+  preFillBtn.addEventListener('click', applyPreFill);
 
   fillBtn.addEventListener('click', () => {
     const raw = guessInput.value.trim().replace(/\./g, '');


### PR DESCRIPTION
## Summary
- Automatically prefill the input with the common prefix after each guess
- Document automatic prefilling based on range hints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899427023288323b4fde872b17ae22b